### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.sikkerhet/ @mortenaatkartverket
+/.security/ @mortenaatkartverket

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: IT
 product: 
 repo_types: [Documentation]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,29 +9,3 @@ spec:
   type: "documentation"
   lifecycle: "production"
   owner: "it"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_qmsrelease"
-  title: "Security Champion qmsrelease"
-spec:
-  type: "security_champion"
-  parent: "it_security_champions"
-  members:
-  - "mortenaatkartverket"
-  children:
-  - "resource:qmsrelease"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "qmsrelease"
-  links:
-  - url: "https://github.com/kartverket/qmsrelease"
-    title: "qmsrelease på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_qmsrelease"
-  dependencyOf:
-  - "component:qmsrelease"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml